### PR TITLE
67 ビデオ再生画面の作成

### DIFF
--- a/lib/common/format.dart
+++ b/lib/common/format.dart
@@ -3,4 +3,5 @@ abstract class Format {
   static const String DATETIME_YYYYMMDD_JP = "yyyy年MM月dd日";
   static const String DATETIME_HHMM = "HH:mm";
   static const String DATETIME_HHMM_JP = "HH時mm分";
+  static const String DATETIME_YYYYMMDDHHMM = "yyyy/MM/dd HH:mm";
 }

--- a/lib/common/my_styles.dart
+++ b/lib/common/my_styles.dart
@@ -13,12 +13,12 @@ abstract class MyStyles {
       height: 1.1,
       color: Theme.of(context).colorScheme.onBackground,
       fontWeight: FontWeight.bold,
-      fontSize: 15,
+      fontSize: 14,
     );
   }
 
-  // ビデオタイルの動画ホスト名テキスト
-  static TextStyle tileHostNameText(BuildContext context) {
+  // ビデオタイルの動画ホスト名テキスト、VideoPlayPageの視聴回数、日時、タグ、アイコン下テキスト
+  static TextStyle font10(BuildContext context) {
     return TextStyle(
       fontSize: 10,
       color: Theme.of(context).colorScheme.onBackground,
@@ -30,6 +30,25 @@ abstract class MyStyles {
     return TextStyle(
       fontSize: 12,
       color: Theme.of(context).colorScheme.onBackground,
+    );
+  }
+
+  // VideoPlayPageのホスト名テキスト
+  static TextStyle hostText(BuildContext context) {
+    return TextStyle(
+      fontSize: 14,
+      height: 0,
+      fontWeight: FontWeight.bold,
+      color: Theme.of(context).colorScheme.onBackground,
+    );
+  }
+
+  // VideoPlayPageのホスト名テキスト
+  static TextStyle followButtonText(BuildContext context) {
+    return TextStyle(
+      fontSize: 10,
+      fontWeight: FontWeight.bold,
+      color: Theme.of(context).colorScheme.tertiary,
     );
   }
 

--- a/lib/common/my_styles.dart
+++ b/lib/common/my_styles.dart
@@ -43,7 +43,7 @@ abstract class MyStyles {
     );
   }
 
-  // VideoPlayPageのホスト名テキスト
+  // VideoPlayPageの”+フォローする”ボタン
   static TextStyle followButtonText(BuildContext context) {
     return TextStyle(
       fontSize: 10,

--- a/lib/common/routes.dart
+++ b/lib/common/routes.dart
@@ -4,6 +4,7 @@ import 'package:happyo/page/home_page.dart';
 import 'package:happyo/page/profile/profile_page.dart';
 import 'package:happyo/page/seach_page.dart';
 import 'package:happyo/page/search_result_page.dart';
+import 'package:happyo/page/video_play_page.dart';
 
 abstract class Routes {
   static const String index = '/';
@@ -11,6 +12,7 @@ abstract class Routes {
   static const String search = 'search';
   static const String searchResult = 'search/result';
   static const String eventCreate = 'event/create';
+  static const String videoPlay = 'videoPlay';
 
   static Map<String, Widget Function(BuildContext)> get routes {
     return {
@@ -28,6 +30,9 @@ abstract class Routes {
       },
       eventCreate: (context) {
         return EventCreatePage();
+      },
+      videoPlay: (context) {
+        return VideoPlayPage();
       },
     };
   }

--- a/lib/page/video_play_page.dart
+++ b/lib/page/video_play_page.dart
@@ -70,7 +70,6 @@ class _VideoPlayPageState extends State<VideoPlayPage> {
           ),
         ],
       ),
-      drawer: SideMenu(),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/page/video_play_page.dart
+++ b/lib/page/video_play_page.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/basic.dart';
+import 'package:flutter/src/widgets/container.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:happyo/common/my_styles.dart';
+import 'package:happyo/model/movie/movie.dart';
+import 'package:happyo/widgets/play_list.dart';
+import 'package:intl/intl.dart';
+import 'package:youtube_player_iframe/youtube_player_iframe.dart';
+
+import '../common/format.dart';
+import '../common/routes.dart';
+import '../widgets/side_menu.dart';
+import '../widgets/youtube_player.dart';
+
+class VideoPlayPage extends StatelessWidget {
+  const VideoPlayPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Movie? movie = Routes.getArgs(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Text(
+              'HAPPY',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onBackground,
+              ),
+            ),
+            Text(
+              'O',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.tertiary,
+              ),
+            ),
+          ],
+        ),
+        centerTitle: false,
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: 10,
+              horizontal: 12,
+            ),
+            child: TextButton(
+              onPressed: () {
+                Routes.pushNamed(context, Routes.eventCreate);
+              },
+              child: const Text('イベント作成'),
+            ),
+          ),
+          IconButton(
+            onPressed: () {
+              Routes.pushNamed(context, Routes.search);
+            },
+            icon: const Icon(Icons.search),
+          ),
+        ],
+      ),
+      drawer: SideMenu(),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          YouTubePlayer(
+            videoId: '${movie!.youtubeId}',
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '${movie.title}',
+                        maxLines: 2,
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.onBackground,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                        padding: EdgeInsets.zero,
+                        alignment: Alignment.topRight,
+                        onPressed: () {},
+                        icon: const Icon(
+                          Icons.keyboard_arrow_down,
+                          size: 20,
+                        )),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '${movie.views}回視聴',
+                          style: MyStyles.font10(context),
+                        ),
+                        Text(
+                          DateFormat(Format.DATETIME_YYYYMMDDHHMM)
+                              .format(movie.postedAt!),
+                          style: MyStyles.font10(context),
+                        ),
+                      ],
+                    ),
+                    SizedBox(
+                      height: 16,
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        physics: const ClampingScrollPhysics(),
+                        scrollDirection: Axis.horizontal,
+                        itemCount: movie.tag!.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(right: 4.0),
+                            child: Text(
+                              '#${movie.tag![index].toString()}',
+                              style: MyStyles.font10(context),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 8,
+                    ),
+                    Center(
+                      child: SizedBox(
+                        width: MediaQuery.of(context).size.width * 0.9,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            InkWell(
+                              onTap: () {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(
+                                  content: Text('未実装です'),
+                                  duration: Duration(milliseconds: 300),
+                                ));
+                              },
+                              child: Column(
+                                children: [
+                                  const Icon(Icons.thumb_up),
+                                  Text(
+                                    '${movie.likes}',
+                                    style: MyStyles.font10(context),
+                                  )
+                                ],
+                              ),
+                            ),
+                            InkWell(
+                              onTap: () {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(
+                                  content: Text('未実装です'),
+                                  duration: Duration(milliseconds: 300),
+                                ));
+                              },
+                              child: Column(
+                                children: [
+                                  const Icon(Icons.add),
+                                  Text(
+                                    'マイリスト',
+                                    style: MyStyles.font10(context),
+                                  )
+                                ],
+                              ),
+                            ),
+                            InkWell(
+                              onTap: () {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(
+                                  content: Text('未実装です'),
+                                  duration: Duration(milliseconds: 300),
+                                ));
+                              },
+                              child: Column(
+                                children: [
+                                  const Icon(Icons.share),
+                                  Text(
+                                    '共有',
+                                    style: MyStyles.font10(context),
+                                  )
+                                ],
+                              ),
+                            ),
+                            InkWell(
+                              onTap: () {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(
+                                  content: Text('未実装です'),
+                                  duration: Duration(milliseconds: 300),
+                                ));
+                              },
+                              child: Column(
+                                children: [
+                                  const Icon(Icons.download),
+                                  Text(
+                                    'ダウンロード',
+                                    style: MyStyles.font10(context),
+                                  )
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const Padding(
+                      padding: EdgeInsets.all(0),
+                      child: Divider(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          // TODO : チャンネルプロフィール画像取得、表示
+                          // const CircleAvatar(
+                          //   backgroundImage: null,
+                          // ),
+                          InkWell(
+                            onTap: () {
+                              ScaffoldMessenger.of(context)
+                                  .showSnackBar(const SnackBar(
+                                content: Text('未実装です'),
+                                duration: Duration(milliseconds: 300),
+                              ));
+                            },
+                            child: Text(
+                              '${movie.hostName}',
+                              style: MyStyles.hostText(context),
+                            ),
+                          ),
+                          SizedBox(
+                            height: 16,
+                            child: TextButton(
+                              style: TextButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 2,
+                                  horizontal: 8,
+                                ),
+                              ),
+                              onPressed: () {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(
+                                  content: Text('未実装です'),
+                                  duration: Duration(milliseconds: 300),
+                                ));
+                              },
+                              child: Text('+ フォローする',
+                                  style: MyStyles.followButtonText(context)),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Padding(
+                      padding: EdgeInsets.all(0),
+                      child: Divider(),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const Expanded(child: PlayList()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/video_play_page.dart
+++ b/lib/page/video_play_page.dart
@@ -13,8 +13,19 @@ import '../common/routes.dart';
 import '../widgets/side_menu.dart';
 import '../widgets/youtube_player.dart';
 
-class VideoPlayPage extends StatelessWidget {
+class VideoPlayPage extends StatefulWidget {
   const VideoPlayPage({super.key});
+
+  @override
+  State<VideoPlayPage> createState() => _VideoPlayPageState();
+}
+
+class _VideoPlayPageState extends State<VideoPlayPage> {
+  bool isVisible = true;
+
+  void toggleShowText() {
+    isVisible = !isVisible;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -86,59 +97,162 @@ class VideoPlayPage extends StatelessWidget {
                       ),
                     ),
                     IconButton(
-                        padding: EdgeInsets.zero,
-                        alignment: Alignment.topRight,
-                        onPressed: () {},
-                        icon: const Icon(
-                          Icons.keyboard_arrow_down,
-                          size: 20,
-                        )),
+                      padding: EdgeInsets.zero,
+                      alignment: Alignment.topRight,
+                      onPressed: () {
+                        setState(
+                          () {
+                            toggleShowText();
+                          },
+                        );
+                      },
+                      icon: isVisible
+                          ? const Icon(
+                              Icons.keyboard_arrow_down,
+                              size: 20,
+                            )
+                          : const Icon(
+                              Icons.keyboard_arrow_up,
+                              size: 20,
+                            ),
+                    ),
                   ],
                 ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          '${movie.views}回視聴',
-                          style: MyStyles.font10(context),
-                        ),
-                        Text(
-                          DateFormat(Format.DATETIME_YYYYMMDDHHMM)
-                              .format(movie.postedAt!),
-                          style: MyStyles.font10(context),
-                        ),
-                      ],
-                    ),
-                    SizedBox(
-                      height: 16,
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        physics: const ClampingScrollPhysics(),
-                        scrollDirection: Axis.horizontal,
-                        itemCount: movie.tag!.length,
-                        itemBuilder: (BuildContext context, int index) {
-                          return Padding(
-                            padding: const EdgeInsets.only(right: 4.0),
-                            child: Text(
-                              '#${movie.tag![index].toString()}',
-                              style: MyStyles.font10(context),
-                            ),
-                          );
-                        },
+                Visibility(
+                  visible: isVisible,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            '${movie.views}回視聴',
+                            style: MyStyles.font10(context),
+                          ),
+                          Text(
+                            DateFormat(Format.DATETIME_YYYYMMDDHHMM)
+                                .format(movie.postedAt!),
+                            style: MyStyles.font10(context),
+                          ),
+                        ],
                       ),
-                    ),
-                    const SizedBox(
-                      height: 8,
-                    ),
-                    Center(
-                      child: SizedBox(
-                        width: MediaQuery.of(context).size.width * 0.9,
+                      SizedBox(
+                        height: 16,
+                        child: ListView.builder(
+                          shrinkWrap: true,
+                          physics: const ClampingScrollPhysics(),
+                          scrollDirection: Axis.horizontal,
+                          itemCount: movie.tag!.length,
+                          itemBuilder: (BuildContext context, int index) {
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 4.0),
+                              child: Text(
+                                '#${movie.tag![index].toString()}',
+                                style: MyStyles.font10(context),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(
+                        height: 8,
+                      ),
+                      Center(
+                        child: SizedBox(
+                          width: MediaQuery.of(context).size.width * 0.9,
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                            children: [
+                              InkWell(
+                                onTap: () {
+                                  ScaffoldMessenger.of(context)
+                                      .showSnackBar(const SnackBar(
+                                    content: Text('未実装です'),
+                                    duration: Duration(milliseconds: 300),
+                                  ));
+                                },
+                                child: Column(
+                                  children: [
+                                    const Icon(Icons.thumb_up),
+                                    Text(
+                                      '${movie.likes}',
+                                      style: MyStyles.font10(context),
+                                    )
+                                  ],
+                                ),
+                              ),
+                              InkWell(
+                                onTap: () {
+                                  ScaffoldMessenger.of(context)
+                                      .showSnackBar(const SnackBar(
+                                    content: Text('未実装です'),
+                                    duration: Duration(milliseconds: 300),
+                                  ));
+                                },
+                                child: Column(
+                                  children: [
+                                    const Icon(Icons.add),
+                                    Text(
+                                      'マイリスト',
+                                      style: MyStyles.font10(context),
+                                    )
+                                  ],
+                                ),
+                              ),
+                              InkWell(
+                                onTap: () {
+                                  ScaffoldMessenger.of(context)
+                                      .showSnackBar(const SnackBar(
+                                    content: Text('未実装です'),
+                                    duration: Duration(milliseconds: 300),
+                                  ));
+                                },
+                                child: Column(
+                                  children: [
+                                    const Icon(Icons.share),
+                                    Text(
+                                      '共有',
+                                      style: MyStyles.font10(context),
+                                    )
+                                  ],
+                                ),
+                              ),
+                              InkWell(
+                                onTap: () {
+                                  ScaffoldMessenger.of(context)
+                                      .showSnackBar(const SnackBar(
+                                    content: Text('未実装です'),
+                                    duration: Duration(milliseconds: 300),
+                                  ));
+                                },
+                                child: Column(
+                                  children: [
+                                    const Icon(Icons.download),
+                                    Text(
+                                      'ダウンロード',
+                                      style: MyStyles.font10(context),
+                                    )
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const Padding(
+                        padding: EdgeInsets.all(0),
+                        child: Divider(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
                         child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
+                            // TODO : チャンネルプロフィール画像取得、表示
+                            // const CircleAvatar(
+                            //   backgroundImage: null,
+                            // ),
                             InkWell(
                               onTap: () {
                                 ScaffoldMessenger.of(context)
@@ -147,128 +261,40 @@ class VideoPlayPage extends StatelessWidget {
                                   duration: Duration(milliseconds: 300),
                                 ));
                               },
-                              child: Column(
-                                children: [
-                                  const Icon(Icons.thumb_up),
-                                  Text(
-                                    '${movie.likes}',
-                                    style: MyStyles.font10(context),
-                                  )
-                                ],
+                              child: Text(
+                                '${movie.hostName}',
+                                style: MyStyles.hostText(context),
                               ),
                             ),
-                            InkWell(
-                              onTap: () {
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(const SnackBar(
-                                  content: Text('未実装です'),
-                                  duration: Duration(milliseconds: 300),
-                                ));
-                              },
-                              child: Column(
-                                children: [
-                                  const Icon(Icons.add),
-                                  Text(
-                                    'マイリスト',
-                                    style: MyStyles.font10(context),
-                                  )
-                                ],
-                              ),
-                            ),
-                            InkWell(
-                              onTap: () {
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(const SnackBar(
-                                  content: Text('未実装です'),
-                                  duration: Duration(milliseconds: 300),
-                                ));
-                              },
-                              child: Column(
-                                children: [
-                                  const Icon(Icons.share),
-                                  Text(
-                                    '共有',
-                                    style: MyStyles.font10(context),
-                                  )
-                                ],
-                              ),
-                            ),
-                            InkWell(
-                              onTap: () {
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(const SnackBar(
-                                  content: Text('未実装です'),
-                                  duration: Duration(milliseconds: 300),
-                                ));
-                              },
-                              child: Column(
-                                children: [
-                                  const Icon(Icons.download),
-                                  Text(
-                                    'ダウンロード',
-                                    style: MyStyles.font10(context),
-                                  )
-                                ],
+                            SizedBox(
+                              height: 16,
+                              child: TextButton(
+                                style: TextButton.styleFrom(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: 2,
+                                    horizontal: 8,
+                                  ),
+                                ),
+                                onPressed: () {
+                                  ScaffoldMessenger.of(context)
+                                      .showSnackBar(const SnackBar(
+                                    content: Text('未実装です'),
+                                    duration: Duration(milliseconds: 300),
+                                  ));
+                                },
+                                child: Text('+ フォローする',
+                                    style: MyStyles.followButtonText(context)),
                               ),
                             ),
                           ],
                         ),
                       ),
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.all(0),
-                      child: Divider(),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          // TODO : チャンネルプロフィール画像取得、表示
-                          // const CircleAvatar(
-                          //   backgroundImage: null,
-                          // ),
-                          InkWell(
-                            onTap: () {
-                              ScaffoldMessenger.of(context)
-                                  .showSnackBar(const SnackBar(
-                                content: Text('未実装です'),
-                                duration: Duration(milliseconds: 300),
-                              ));
-                            },
-                            child: Text(
-                              '${movie.hostName}',
-                              style: MyStyles.hostText(context),
-                            ),
-                          ),
-                          SizedBox(
-                            height: 16,
-                            child: TextButton(
-                              style: TextButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 2,
-                                  horizontal: 8,
-                                ),
-                              ),
-                              onPressed: () {
-                                ScaffoldMessenger.of(context)
-                                    .showSnackBar(const SnackBar(
-                                  content: Text('未実装です'),
-                                  duration: Duration(milliseconds: 300),
-                                ));
-                              },
-                              child: Text('+ フォローする',
-                                  style: MyStyles.followButtonText(context)),
-                            ),
-                          ),
-                        ],
+                      const Padding(
+                        padding: EdgeInsets.all(0),
+                        child: Divider(),
                       ),
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.all(0),
-                      child: Divider(),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/lib/widgets/video_tile.dart
+++ b/lib/widgets/video_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:happyo/common/my_styles.dart';
+import 'package:happyo/common/routes.dart';
 import 'package:happyo/model/movie/movie.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:line_icons/line_icons.dart';
@@ -11,73 +12,82 @@ class VideoTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return SizedBox(
-      height: 100,
-      child: Row(
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(left: 8.0, right: 0),
-            child: SizedBox(
-              height: 88,
-              width: 144,
-              child: Image.network(
-                'http://img.youtube.com/vi/${movie.youtubeId.toString()}/mqdefault.jpg',
-                fit: BoxFit.cover,
+    return InkWell(
+      onTap: () {
+        Routes.pushNamed(
+          context,
+          Routes.videoPlay,
+          args: movie,
+        );
+      },
+      child: SizedBox(
+        height: 100,
+        child: Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 8.0, right: 0),
+              child: SizedBox(
+                height: 88,
+                width: 144,
+                child: Image.network(
+                  'http://img.youtube.com/vi/${movie.youtubeId.toString()}/mqdefault.jpg',
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
-          ),
-          Expanded(
-            child: ListTile(
-              tileColor: Theme.of(context).colorScheme.background,
-              title: Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 3,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(movie.title.toString(),
-                        maxLines: 3, style: MyStyles.tileTitleText(context)),
-                    Text(
-                      movie.hostName.toString(),
-                      maxLines: 1,
-                      style: MyStyles.tileHostNameText(context),
-                    ),
-                    const SizedBox(height: 4),
-                    SizedBox(
-                      height: 14,
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        physics: const ClampingScrollPhysics(),
-                        scrollDirection: Axis.horizontal,
-                        itemCount: movie.tag!.length,
-                        itemBuilder: (BuildContext context, int index) {
-                          return Padding(
-                            padding: const EdgeInsets.only(right: 4.0),
-                            child: Text(
-                              '#${movie.tag![index].toString()}',
-                              style: MyStyles.tileTagNameText(context),
-                            ),
-                          );
-                        },
+            Expanded(
+              child: ListTile(
+                tileColor: Theme.of(context).colorScheme.background,
+                title: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 3,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(movie.title.toString(),
+                          maxLines: 3, style: MyStyles.tileTitleText(context)),
+                      Text(
+                        movie.hostName.toString(),
+                        maxLines: 1,
+                        style: MyStyles.font10(context),
                       ),
-                    )
+                      const SizedBox(height: 4),
+                      SizedBox(
+                        height: 14,
+                        child: ListView.builder(
+                          shrinkWrap: true,
+                          physics: const ClampingScrollPhysics(),
+                          scrollDirection: Axis.horizontal,
+                          itemCount: movie.tag!.length,
+                          itemBuilder: (BuildContext context, int index) {
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 4.0),
+                              child: Text(
+                                '#${movie.tag![index].toString()}',
+                                style: MyStyles.tileTagNameText(context),
+                              ),
+                            );
+                          },
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+                trailing: Column(
+                  //アイコンがリストタイルの中央に配置
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // videoHolder (0:Happyo, 1:YouTube)
+                    movie.videoHolder == 0
+                        ? const Icon(Icons.movie)
+                        : const Icon(LineIcons.youtube),
                   ],
                 ),
               ),
-              trailing: Column(
-                //アイコンがリストタイルの中央に配置
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // videoHolder (0:Happyo, 1:YouTube)
-                  movie.videoHolder == 0
-                      ? const Icon(Icons.movie)
-                      : const Icon(LineIcons.youtube),
-                ],
-              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
# 実装したこと
- タイトルや再生画面の表示
- ビデオタイル選択で画面遷移
- タイトル詳細をトグルボタンで表示非表示

# できていないこと
- 高評価やマイリストなどのアイコンボタンの機能実装
- チャンネル名、フォローするボタンをタップ時の機能実装


# 画像
## 動画タイトル詳細表示
<img src="https://user-images.githubusercontent.com/106295898/191658581-21d20cf7-4448-46a6-843e-b824912be52e.png" width="320px">


## 動画タイトル詳細非表示
<img src="https://user-images.githubusercontent.com/106295898/191658918-d8c870b8-daac-402e-bc7e-ddeb9bcabe92.png" width="320px">
