### PR TITLE
usersMovieListに未登録時の処理を追加

### DIFF
--- a/lib/infrastructure/repository/movies_repository.dart
+++ b/lib/infrastructure/repository/movies_repository.dart
@@ -60,9 +60,11 @@ class MoviesRepository {
 
   Future<bool> addMovieToUsersMovieList(String listName, Movie movie) async {
     // DocumentReference<Map<String, dynamic>> docRef;
-    final snapshot = await _db
-        .collection('usersMovieList')
-        .where('userId', isEqualTo: FirebaseAuth.instance.currentUser!.uid)
+    final docRef = _db.collection('usersMovieList');
+    final userId = FirebaseAuth.instance.currentUser!.uid;
+
+    final snapshot = await docRef
+        .where('userId', isEqualTo: userId)
         .where('listName', isEqualTo: listName)
         .get();
     if (snapshot.docs.isNotEmpty) {
@@ -77,6 +79,19 @@ class MoviesRepository {
             .set(movie.toJson());
         return true;
       }
+    } else {
+      // userId,listNameが登録されていないとき
+      // userId,listNameの登録
+      docRef.doc(userId).set({
+        'userId': userId,
+        'listName': listName,
+      });
+      // myListに追加した動画の情報登録
+      docRef
+          .doc(userId)
+          .collection('listMovies')
+          .doc(movie.id)
+          .set(movie.toJson());
     }
     return false;
   }


### PR DESCRIPTION
Cloud FirestoreのusersMovieListにユーザーが未登録時の時、
データをFirestoreに登録できていないかったので、
処理を追加しまいした。

自分の方ではAppleアカウントで確認できていないです。
(Appleアカウントでログインしようとするとパスワードを入力してから進まなくなってしまいました...)

2種類のgoogleアカウントで試したところマイリストに反映されていたためプルリクエストを送ります！